### PR TITLE
Fixed bug for showing wms style

### DIFF
--- a/frontend/src/components/map/Map.js
+++ b/frontend/src/components/map/Map.js
@@ -200,7 +200,7 @@ export default {
         request: 'GetMap',
         format: 'image/png',
         layers: 'pub:' + layer.wms_name,
-        styles: layer.wmsStyle,
+        styles: layer.wms_style,
         transparent: true,
         name: layer.name,
         height: 256,


### PR DESCRIPTION
When you check 'Water Allocation Restrictions' layers it doesn't show the correct style for that map layer