### PR TITLE
Padding for Ground water Feature Requests

### DIFF
--- a/frontend/src/components/map/Map.js
+++ b/frontend/src/components/map/Map.js
@@ -204,8 +204,8 @@ export default {
         display_data_name: data.result.layer,
         pk: data.result.primary_id
       }
-      // Our search db view trims the pks on search so we
-      // need to add the 00s back on feature requests 
+      // Our search db view trims the pks on gwells queries
+      // so here we add the 00s back for feature requests
       if(payload.display_data_name === "groundwater_wells") {
         payload.pk = payload.pk.padStart(12, '0')
       }


### PR DESCRIPTION
The search db view trims the 0s off of the groundwater_wells primary key so we just need to add those zeros back when we do a feature request from a search result.