### PR TITLE
Hotfix for bug that doesn't compute apportionment

### DIFF
--- a/frontend/src/components/analysis/StreamApportionment.js
+++ b/frontend/src/components/analysis/StreamApportionment.js
@@ -242,7 +242,7 @@ export default {
       this.fetchStreams()
     },
     weightingFactor (value) {
-      if (value > 1 && value < 4) {
+      if (parseFloat(value) === 1 || parseFloat(value) === 2) {
         this.calculateApportionment()
       }
     }


### PR DESCRIPTION
Bug found when you change the weighting factor, the apportionment doesn't get recomputed. The reason is because it was originally set to wrong values (2 or 3 when it's supposed to be 1 or 3)