### PR TITLE
Fix for model outputs summary

### DIFF
--- a/backend/api/v1/models/scsb2016/controller.py
+++ b/backend/api/v1/models/scsb2016/controller.py
@@ -164,7 +164,7 @@ def model_output_as_dict(data: list):
             mar = item
 
         elif output_type == 'MD':
-            month = item.pop('month')
+            month = item.get('month')
             # each month must only have one record in the model output,
             # so assert that this month has not been more than once
             assert monthly_distributions.get(month, None) is None
@@ -173,16 +173,14 @@ def model_output_as_dict(data: list):
 
         elif output_type == '7Q2':
             assert ind_7q2 is None
-            item.pop('month', None)  # month is not needed
             ind_7q2 = item
 
         elif output_type == 'S-7Q10':
             assert ind_s7q10 is None
-            item.pop('month', None)
             ind_s7q10 = item
 
         elif output_type == 'MAD':
-            month = item.pop('month')
+            month = item.get('month')
 
             if month == 0:
                 # month = 0 is the annual result

--- a/frontend/src/components/map/Map.js
+++ b/frontend/src/components/map/Map.js
@@ -221,9 +221,9 @@ export default {
         // so we don't need to check for layer type anymore
         const layerName = layer['display_data_name']
         // we use a custom cursor for stream selection so we dont set the cursor for it
-        if (layerName !== 'freshwater_atlas_stream_networks') { 
-            this.map.on('mouseenter', layerName, this.setCursorPointer)
-            this.map.on('mouseleave', layerName, this.resetCursor)
+        if (layerName !== 'freshwater_atlas_stream_networks') {
+          this.map.on('mouseenter', layerName, this.setCursorPointer)
+          this.map.on('mouseleave', layerName, this.resetCursor)
         }
       }
     },

--- a/frontend/src/components/sidepanel/cards/UpstreamDownstream.vue
+++ b/frontend/src/components/sidepanel/cards/UpstreamDownstream.vue
@@ -90,14 +90,14 @@ export default {
       if (value && value.geometry) {
         this.buttonClicked = false
         const params = {
-            point: JSON.stringify(value.geometry.coordinates),
-            limit: 1,
-            get_all: true,
-            with_apportionment: false
+          point: JSON.stringify(value.geometry.coordinates),
+          limit: 1,
+          get_all: true,
+          with_apportionment: false
         }
         ApiService.query(`/api/v1/streams/nearby?${qs.stringify(params)}`).then((r) => {
           let geojson = r.data.streams[0].geojson
-          geojson.display_data_name = "freshwater_atlas_stream_networks"
+          geojson.display_data_name = 'freshwater_atlas_stream_networks'
           // the nearby endpoint returns values in lower snake case, we capatalize them for consistency
           geojson.properties.LINEAR_FEATURE_ID = geojson.properties.linear_feature_id
           geojson.properties.FWA_WATERSHED_CODE = geojson.properties.fwa_watershed_code


### PR DESCRIPTION
This fixes the model outputs summary page, which was getting an error because the months were being mistakenly removed with `.pop('month')`