### PR TITLE
Remove API_VERSION from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -439,7 +439,6 @@ pipeline {
                   "NAMESPACE=${project}",
                   "ENVIRONMENT=STAGING",
                   "WALLY_VERSION=${git_tag}",
-                  "API_VERSION=${API_VERSION}",
                   "REPLICAS=2"
                 ))
 
@@ -551,7 +550,6 @@ pipeline {
                   "NAMESPACE=${project}",
                   "ENVIRONMENT=PRODUCTION",
                   "WALLY_VERSION=${git_tag}",
-                  "API_VERSION=${API_VERSION}",
                   "REPLICAS=2"
                 ))
 


### PR DESCRIPTION
A default is set from the deployment config, overridden by an environment variable in OpenShift