### PR TITLE
Fix for user's full name (for new Keycloak realm)

### DIFF
--- a/frontend/src/services/AuthService.js
+++ b/frontend/src/services/AuthService.js
@@ -32,7 +32,7 @@ export class AuthService {
   }
 
   login (next) {
-    this.name = this.accessToken['display_name'] || this.accessToken['given_name']
+    this.name = this.accessToken['display_name'] || this.accessToken['name'] || this.accessToken['given_name']
 
     // required for allowing header to update the name.
     EventBus.$emit('auth:update', { name: this.name, authenticated: this.isAuthenticated() })


### PR DESCRIPTION
Fixes the way a user's name is displayed in the top right corner. With the new Keycloak realm, it only shows the first name, not the full name.
I think this was actually an error in the old realm config, since `given_name` should have only been the first name.