### PR TITLE
Assign id to a user in matomo

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -103,10 +103,14 @@ export default {
       global.config.debug && console.log('[wally] toggling')
       this.$store.commit('toggleAdjustableSidePanel')
     },
-    setName (payload) {
-      const { name, authenticated } = payload
+    updateAuth (payload) {
+      const { name, uuid, authenticated } = payload
       if (authenticated) {
+        // Set the user's name
         this.name = name
+
+        // Track unique user
+        window._paq.push(['setUserId', uuid])
       }
     },
     openFeedback () {
@@ -115,10 +119,10 @@ export default {
   },
   created () {
     this.name = (this.$auth && this.$auth.name) || '' // fallback value if auth status not yet available
-    EventBus.$on('auth:update', this.setName)
+    EventBus.$on('auth:update', this.updateAuth)
   },
   beforeDestroy () {
-    EventBus.$off('auth:update', this.setName)
+    EventBus.$off('auth:update', this.updateAuth)
   }
 }
 </script>

--- a/frontend/src/services/AuthService.js
+++ b/frontend/src/services/AuthService.js
@@ -6,6 +6,7 @@ export class AuthService {
   accessToken
   idToken
   name
+  uuid
   authenticated
 
   init (options) {
@@ -13,8 +14,11 @@ export class AuthService {
       // local environment pseudo-token.  All tokens/sessions are handled by Keycloak gatekeeper, so
       // the vue app is not responsible for any token handling. We just need some user info.
       if (process.env.VUE_APP_ENV === 'dev') {
-        this.accessToken = { given_name: 'Wally User', realm_access: { roles: ['wally-view'] } }
-        this.authenticated = true
+        this.accessToken = {
+          given_name: 'Wally User',
+          realm_access: { roles: ['wally-view'] },
+          sub: '00000000-0000-0000-0000-00000'
+        }
         this.login()
         resolve()
         return
@@ -33,6 +37,7 @@ export class AuthService {
 
   login (next) {
     this.name = this.accessToken['display_name'] || this.accessToken['name'] || this.accessToken['given_name']
+    this.uuid = this.accessToken['sub']
 
     // required for allowing header to update the name.
     EventBus.$emit('auth:update', { name: this.name, authenticated: this.isAuthenticated() })


### PR DESCRIPTION
To track when an authenticated user logs in to a different computer/network...they won't be counted as 2 unique visits