### PR TITLE
Fix map legend bug

### DIFF
--- a/frontend/src/components/map/maplegend/LegendItem.vue
+++ b/frontend/src/components/map/maplegend/LegendItem.vue
@@ -48,7 +48,7 @@ export default {
       return this.item.strokeWidth ? this.item.strokeWidth + 'px' : '1px'
     },
     strokeColor () {
-      return this.item.outlineColor
+      return this.item.outlineColor ? this.item.outlineColor : null
     }
   }
 }

--- a/frontend/src/store/mapStore.js
+++ b/frontend/src/store/mapStore.js
@@ -567,8 +567,6 @@ export default {
       state.layerCategories = payload
     },
     setActiveMapLayers (state, payload) {
-      // TODO: See if this is actually used anywhere else
-      // Could have been deprecated by updateActiveMapLayers
       state.activeMapLayers = state.mapLayers.filter((l) => {
         return payload.includes(l.display_data_name)
       })


### PR DESCRIPTION
Bug with the way the map legend displays the layer icons. To test:

- Select "Freshwater Atlas Stream Networks" 
   - 1 Legend item, icon type line, color blue
- Select "Automated Snow Weather Station Locations"
   - 2 legend items
     - 1 icon type point color white w/outline color cyan
     - 1 icon type line, color blue
- Deselect  "Automated Snow Weather Station Locations"
   - 1 legend item, icon type line, color blue w/outline color cyan (incorrect, bug)