### PR TITLE
Rename all references of "Upload" to "Import" 

### DIFF
--- a/frontend/src/common/utils/Importer.js
+++ b/frontend/src/common/utils/Importer.js
@@ -115,7 +115,7 @@ export default class Importer {
       store.commit('importer/clearQueuedFiles')
 
       // Custom Metrics - Import files
-      window._paq && window._paq.push(['trackEvent', 'Upload files', 'Unsupported filetype', fileType])
+      window._paq && window._paq.push(['trackEvent', 'Import files', 'Unsupported filetype', fileType])
       return
     }
 
@@ -293,7 +293,7 @@ export default class Importer {
       store.dispatch('importer/processFile', {
         filenames: [(dbfFile && dbfFile.name), (prjFile && prjFile.name)],
         status: 'error',
-        message: 'It looks like you\'re uploading a shapefile. Please' +
+        message: 'It looks like you\'re importing a shapefile. Please' +
           ' provide the .shp and .prj file.'
       })
       return
@@ -409,13 +409,13 @@ export default class Importer {
 
     // basic test to assert that the first feature is near BC.
     // this will only be a warning and will only be reliable if all the features are outside BC.
-    // the most common case will be when users upload data in non WGS84 coordinate systems.
+    // the most common case will be when users import data in non WGS84 coordinate systems.
     // todo: investigate if better warnings are required based on user feedback.
 
     // using [-139.06 48.30],  [-114.03  60.00] as extents of BC.
     if (!(firstFeature[0] > -180 && firstFeature[0] < 180) || !(firstFeature[1] > -90 && firstFeature[1] < 90)) {
       throw new Error('Coordinates are not in degrees. If this is a' +
-        ' shapefile, please upload a .prj file with the same name')
+        ' shapefile, please import a .prj file with the same name')
     }
     return firstFeature
   }
@@ -459,7 +459,7 @@ export default class Importer {
       }).finally(() => {
         // Custom Metrics - Import files
         window._paq && window._paq.push(
-          ['trackEvent', 'Upload files', 'Uploaded Filetype', fileType])
+          ['trackEvent', 'Import files', 'Imported Filetype', fileType])
 
         store.dispatch('importer/processFile', fileStatus)
       })

--- a/frontend/src/components/sidepanel/cards/ImportLayer.vue
+++ b/frontend/src/components/sidepanel/cards/ImportLayer.vue
@@ -2,7 +2,7 @@
   <v-container class="pt-5">
     <v-toolbar flat>
       <v-banner color="indigo" icon="mdi-cloud-upload" icon-color="white" width="100%">
-        <v-toolbar-title>Upload file or data</v-toolbar-title>
+        <v-toolbar-title>Import file or data</v-toolbar-title>
       </v-banner>
     </v-toolbar>
     <v-row>

--- a/frontend/src/components/toolbar/LayerSelection.vue
+++ b/frontend/src/components/toolbar/LayerSelection.vue
@@ -10,10 +10,10 @@
             small
             color="grey darken-2"
             text
-            :to="{ name: 'upload-data-layer' }"
+            :to="{ name: 'import-data-layer' }"
             @click="$emit('closeDialog')"
             v-if="this.app.config && this.app.config.external_import">
-            <v-icon small>mdi-cloud-upload</v-icon> Upload file or data
+            <v-icon small>mdi-cloud-upload</v-icon> Import file or data
           </v-btn>
           <v-btn @click.prevent="handleResetLayers" small color="grey darken-2" text>
             <v-icon>refresh</v-icon> Reset all

--- a/frontend/src/components/toolbar/SelectionMenu.vue
+++ b/frontend/src/components/toolbar/SelectionMenu.vue
@@ -140,8 +140,8 @@ export default {
 
       let externalImport =
       {
-        title: 'Upload file or data',
-        route: { name: 'upload-data-layer' },
+        title: 'Import file or data',
+        route: { name: 'import-data-layer' },
         icon: 'mdi-cloud-upload'
       }
 

--- a/frontend/src/components/tools/import_layer/ImportLayerInstructions.vue
+++ b/frontend/src/components/tools/import_layer/ImportLayerInstructions.vue
@@ -7,16 +7,16 @@
       Imported files require a location in order to be displayed. The supported coordinated system is decimal
       degrees longitude/latitude (WGS84). For example, -127.10205, 51.81051
     </p>
-    <p>Large or complex files may impact performance. A message will indicate if the file has been successfully uploaded.</p>
+    <p>Large or complex files may impact performance. A message will indicate if the file has been successfully imported.</p>
     <h3>CSV and Excel</h3>
     <p>
       For CSV and Excel, the files should have two columns with the headings (not case sensitive):
-      "Latitude" and "Longitude" or "lat" and "long". It works best to upload an Excel workbook that has a table on
+      "Latitude" and "Longitude" or "lat" and "long". It works best to import an Excel workbook that has a table on
       the first sheet (and no other cells filled in outside the table).
     </p>
     <h3>Shapefile</h3>
     <p>
-      Shapefiles must include both the .shp and .prj. Uploading the .dbf is also recommended if you want to view features and properties of the layer.
+      Shapefiles must include both the .shp and .prj. Importing the .dbf is also recommended if you want to view features and properties of the layer.
     </p>
   </div>
 </template>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -225,20 +225,14 @@ const router = new Router({
       }
     },
     {
-      path: '/upload-data-layer',
-      name: 'upload-data-layer',
+      path: '/import-data-layer',
+      name: 'import-data-layer',
       component: ImportLayer,
       meta: {
-        title: `Upload File - ${title}`,
+        title: `Import File - ${title}`,
         sidebarColumns: {},
         allowRedirect: true
       }
-    },
-    {
-      // Retired path
-      path: '/import-layer',
-      name: 'import-layer',
-      redirect: '/upload-data-layer'
     },
     {
       path: '/projects',
@@ -250,7 +244,7 @@ const router = new Router({
 
 router.beforeEach((to, from, next) => {
   // Check if feature is enabled
-  if (to.name === 'upload-data-layer' &&
+  if (to.name === 'import-data-layer' &&
     store.getters.app &&
     store.getters.app.config &&
     !store.getters.app.config.external_import) next({ name: 'home' })


### PR DESCRIPTION
on the import file/data feature

[WATER-1557](https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-1557)
Scenario#3:
Given I am importing files in WALLY
When I am reviewing instructions and buttons
Then the term 'import' is used