### PR TITLE
(HYDAT watersheds) treat NULL/FALSE the same during order by

### DIFF
--- a/backend/api/v1/hydat/controller.py
+++ b/backend/api/v1/hydat/controller.py
@@ -84,7 +84,7 @@ def get_point_on_stream(db: Session, station_number: str) -> Point:
         ) as stream_point
       FROM      nearest_streams
       ORDER BY  
-        nearest_streams."GNIS_NAME" ILIKE '%' || (select split_part(station_name, ' ', 1) from stn) || '%' ASC,
+        coalesce(nearest_streams."GNIS_NAME" ILIKE '%' || (select split_part(station_name, ' ', 1) from stn) || '%', FALSE) DESC,
         ST_Distance(nearest_streams."GEOMETRY", (select geom from stn)) ASC
       LIMIT     1
     """


### PR DESCRIPTION
results were different if the results had TRUE/FALSE or TRUE/FALSE/NULL for matches between stream station names and river names.