### PR TITLE
add loading bar for slow loading HYDAT charts

### DIFF
--- a/frontend/src/components/features/FeatureStreamStation.vue
+++ b/frontend/src/components/features/FeatureStreamStation.vue
@@ -8,7 +8,7 @@
         <div v-if="station">Station Number: {{ station.station_number }}</div>
         <div v-if="station">Flow data: {{ formatYears(station.flow_years) }}</div>
         <div v-if="station">Station Status: {{ stationStatus(station.hyd_status) }}</div>
-        <div v-if="station">Gross drainage area: {{ station.drainage_area_gross ? `${station.drainage_area_gross.toFixed(1)} km²` : "" }}</div>
+        <div v-if="station">Gross drainage area: {{ station.drainage_area_gross ? `${station.drainage_area_gross.toFixed(1)} km²` : "N/A" }}</div>
         <div v-if="station">WSC Historical Link: <a :href="`https://wateroffice.ec.gc.ca/report/historical_e.html?stn=${station.station_number}`"
           target="_blank"
         >{{station.station_number}}</a></div>


### PR DESCRIPTION
Provides a loading bar instead of a blank chart while the flow data is loading.

This can be tested at https://wally-pr-573.apps.silver.devops.gov.bc.ca/.
Try the HYDAT station at Fitzsimmons Creek in Whistler (there are only 2 HYDAT stations on dev sites, both in Whistler)