### PR TITLE
Rebuild WhiteboxTools w/node10

### DIFF
--- a/frontend/Dockerfile.ocp4
+++ b/frontend/Dockerfile.ocp4
@@ -1,4 +1,4 @@
-FROM image-registry.openshift-image-registry.svc:5000/d1b5d2-tools/node:10 as build
+FROM image-registry.openshift-image-registry.svc:5000/d1b5d2-tools/node:10.2 as build
 
 WORKDIR /app
 

--- a/openshift/ocp4/whiteboxtools/Dockerfile
+++ b/openshift/ocp4/whiteboxtools/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:latest AS builder
 RUN apt-get update && apt-get install -y musl-tools git && \
   rustup target add x86_64-unknown-linux-musl && \
   git clone https://github.com/mholling/whitebox-tools.git /wbt && \
-  cd /wbt && git checkout d8_flow_accum-fix
+  cd /wbt
 
 WORKDIR /wbt
 


### PR DESCRIPTION
Updated docker files to use the newly built images.

Using the image Node:10.2 - This 10.2 tag is actually version: 10.24.1. This image will most likely be deleted once we complete the upgrade to node:15.

Using the release branch of WhiteboxTools