### PR TITLE
660 - Docker and CDOGS update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Water Allocation Data Library
+# Water Allocation Data Library 
 
 1. [Working on WALLY (Getting started)](#working-on-wally-getting-started)
 1. [Application architecture](#application-architecture)

--- a/backend/Dockerfile.dev.m1
+++ b/backend/Dockerfile.dev.m1
@@ -1,8 +1,9 @@
 ARG DOCKER_TAG=latest
 
-FROM --platform=linux/amd64 rust:latest AS builder
+FROM --platform=linux/amd64 rust:1.67.1 AS builder
+# FROM --platform=linux/amd64 rust:latest AS builder
 
-RUN apt-get update && apt-get install -y musl-tools git && \
+RUN apt-get update && apt-get install -y musl-tools librust-atk-dev libgtk-3-dev git && \
   rustup target add x86_64-unknown-linux-musl && \
   git clone https://github.com/mholling/whitebox-tools.git /wbt
   # NOTE: this branch no longer exists
@@ -10,6 +11,7 @@ RUN apt-get update && apt-get install -y musl-tools git && \
 
 WORKDIR /wbt
 
+RUN cargo clean
 RUN cargo build --release 
 
 FROM --platform=linux/amd64 python:3.7

--- a/backend/external/docgen/controller.py
+++ b/backend/external/docgen/controller.py
@@ -1,4 +1,4 @@
-""" Functions for interacting with the Common Document Generator (CDOGS) API """
+""" Functions for interacting with the Common Document Generator (CDOGS) API  """
 
 import base64
 import requests

--- a/backend/external/docgen/request_token.py
+++ b/backend/external/docgen/request_token.py
@@ -1,25 +1,35 @@
 import requests
+import base64
 from api import config
+from fastapi import HTTPException
+import logging
 
+logger = logging.getLogger('docgen')
 
 def get_docgen_token():
     params = {
-        "grant_type": "client_credentials",
-        "client_id": config.COMMON_DOCGEN_CLIENT_ID,
-        "client_secret": config.COMMON_DOCGEN_CLIENT_SECRET,
-        "scope": ""
+        "grant_type": "client_credentials"
     }
 
-    req = requests.post(
-        config.COMMON_DOCGEN_SSO_ENDPOINT,
-        data=params,
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-    )
-    req.raise_for_status()
+    auth_string = f"{config.COMMON_DOCGEN_CLIENT_ID}:{config.COMMON_DOCGEN_CLIENT_SECRET}"
+    encoded_auth = base64.b64encode(auth_string.encode()).decode()
 
-    resp = req.json()
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Authorization": f"Basic {encoded_auth}"
+    }
 
-    token = req.json().get('access_token')
-    return token
+    logger.info('making POST request to common docgen sso endpoint: %s',
+                config.COMMON_DOCGEN_SSO_ENDPOINT)
+
+    try:
+        res = requests.post(
+            config.COMMON_DOCGEN_SSO_ENDPOINT,
+            data=params,
+            headers=headers)
+        res.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.info(e)
+        raise HTTPException(status_code=e.response.status_code, detail=str(e))
+
+    return res.json().get('access_token')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY:-minio}" # default to the minio service defined below.
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY:-minio123}" 
       MINIO_HOST_URL: "${MINIO_HOST_URL:-minio:9000}"
-      GDAL_DATA: /usr/share/gdal/
+      # GDAL_DATA: /usr/share/gdal/
     ports:
       - '8000:8000'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.3'
 services:
   backend:
+    platform: linux/amd64
     build:
       context: ./backend
       dockerfile: "Dockerfile.dev${PLATFORM}"
@@ -36,6 +37,7 @@ services:
     depends_on:
       - db
   db:
+    platform: linux/amd64
     build: database
     env_file:
       - env-postgres.env
@@ -52,6 +54,7 @@ services:
     ports:
       - '5432:5432'
   tileserv:
+    platform: linux/amd64
     hostname: tileserv
     depends_on:
       - db

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -86,7 +86,6 @@ keycloak.onTokenExpired = function () {
     .then(function (refreshed) {
       if (refreshed) {
         console.log('Token was successfully refreshed')
-        axios.defaults.headers.common['Authorization'] = 'Bearer ' + keycloak.token // Update the token value
       } else {
         console.log('Token is still valid')
       }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -86,6 +86,7 @@ keycloak.onTokenExpired = function () {
     .then(function (refreshed) {
       if (refreshed) {
         console.log('Token was successfully refreshed')
+        axios.defaults.headers.common['Authorization'] = 'Bearer ' + keycloak.token // Update the token value
       } else {
         console.log('Token is still valid')
       }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -86,6 +86,7 @@ keycloak.onTokenExpired = function () {
     .then(function (refreshed) {
       if (refreshed) {
         console.log('Token was successfully refreshed')
+        axios.defaults.headers.common['Authorization'] = 'Bearer ' + keycloak.token
       } else {
         console.log('Token is still valid')
       }


### PR DESCRIPTION
Update Dockerfile.dev.m1:
- Building Rust in Docker requires `atk` and `gdk-3.0`
- Also run `cargo clean` before attempting to rebuild
- Add `platform: linux/amd64` to docker-compose as `db` and `minIO` weren't able to build without it
- Comment out `GDAL_DATA` as it was pointing to a directory that is no longer used

Update to request_token
- CDOGS update requires Basic auth in the request for access token
- Slight change to the request structure, uses try and except to parse errors